### PR TITLE
feat(cli): Add validation for /language, /format, and /connect --type

### DIFF
--- a/graphsh/cli/app.py
+++ b/graphsh/cli/app.py
@@ -180,6 +180,8 @@ class GraphShApp:
         Raises:
             ValueError: If language is not supported.
         """
+        if language == "opencypher":
+            language = "cypher"
         try:
             # Check if we have an active connection and if the language is compatible
             if (

--- a/graphsh/cli/commands.py
+++ b/graphsh/cli/commands.py
@@ -188,6 +188,11 @@ class CommandRegistry:
             return
 
         language = args[0].lower()
+        if language not in ("gremlin", "sparql", "cypher", "opencypher"):
+            console.print(
+                f"[bold red]Invalid language:[/bold red] '{args[0]}'. Available: gremlin, sparql, cypher"
+            )
+            return
         try:
             self.app.set_language(language)
         except ValueError as e:
@@ -312,6 +317,14 @@ class CommandRegistry:
                 )
                 return
 
+            valid_types = ("neptune", "neptune-analytics", "neo4j", "tinkerpop")
+            if connection_params["type"] not in valid_types:
+                console.print(
+                    f"[bold red]Invalid type:[/bold red] '{connection_params['type']}'. "
+                    f"Available: {', '.join(valid_types)}"
+                )
+                return
+
             # Connect using parameters
             if self.app.connect(**connection_params):
                 console.print("[bold green]Connected to database.[/bold green]")
@@ -398,6 +411,11 @@ class CommandRegistry:
             return
 
         format_type = args[0].lower()
+        if format_type not in ("table", "raw"):
+            console.print(
+                f"[bold red]Invalid format:[/bold red] '{args[0]}'. Available: table, raw"
+            )
+            return
         try:
             # Test if renderer exists
             from graphsh.renderers import get_renderer

--- a/graphsh/db/adapters/factory.py
+++ b/graphsh/db/adapters/factory.py
@@ -31,7 +31,7 @@ def get_adapter_for_type(db_type):
         from graphsh.db.adapters.neo4j import Neo4jAdapter
 
         return Neo4jAdapter
-    elif db_type in ["tinkerpop", "gremlin-server"]:
+    elif db_type == "tinkerpop":
         # Use the TinkerPop adapter for Gremlin Server
         from graphsh.db.adapters.tinkerpop import TinkerPopAdapter
 

--- a/graphsh/lang/__init__.py
+++ b/graphsh/lang/__init__.py
@@ -37,4 +37,6 @@ def get_language_processor(language):
     elif language in ["cypher", "opencypher"]:
         return CypherProcessor()
     else:
-        raise ValueError(f"Unsupported language: {language}")
+        raise ValueError(
+            f"Unsupported language: {language}. Available: gremlin, sparql, cypher"
+        )

--- a/tests/test_cli/test_commands.py
+++ b/tests/test_cli/test_commands.py
@@ -58,14 +58,19 @@ def test_cmd_language_with_args(command_registry, mock_app):
         mock_app.set_language.assert_called_once_with("sparql")
 
 
-def test_cmd_language_error(command_registry, mock_app):
-    """Test language command with error."""
-    mock_app.set_language.side_effect = ValueError("Invalid language")
+def test_cmd_language_opencypher(command_registry, mock_app):
+    """Test language command with opencypher alias."""
+    with patch("graphsh.cli.commands.console.print") as mock_print:
+        command_registry.cmd_language(["opencypher"])
+        mock_app.set_language.assert_called_once_with("opencypher")
 
+
+def test_cmd_language_error(command_registry, mock_app):
+    """Test language command with invalid language."""
     with patch("graphsh.cli.commands.console.print") as mock_print:
         command_registry.cmd_language(["invalid"])
         mock_print.assert_called_once_with(
-            "[bold red]Error:[/bold red] Invalid language"
+            "[bold red]Invalid language:[/bold red] 'invalid'. Available: gremlin, sparql, cypher"
         )
 
 
@@ -144,6 +149,18 @@ def test_cmd_connect_direct_missing_endpoint(command_registry):
         )
 
 
+def test_cmd_connect_invalid_type(command_registry):
+    """Test connect command with invalid database type."""
+    with patch("graphsh.cli.commands.console.print") as mock_print:
+        command_registry.cmd_connect(
+            ["--endpoint", "http://localhost", "--type", "invalid"]
+        )
+        mock_print.assert_any_call(
+            "[bold red]Invalid type:[/bold red] 'invalid'. "
+            "Available: neptune, neptune-analytics, neo4j, tinkerpop"
+        )
+
+
 def test_cmd_clear(command_registry):
     """Test clear command."""
     with patch("graphsh.cli.commands.os.system") as mock_system:
@@ -199,13 +216,7 @@ def test_cmd_format(command_registry, mock_app):
 
         # Test with invalid format
         mock_print.reset_mock()
-        with patch(
-            "graphsh.renderers.get_renderer",
-            side_effect=ValueError(
-                "Unsupported renderer type: invalid. Available renderers: table, raw, json, csv"
-            ),
-        ):
-            command_registry.cmd_format(["invalid"])
-            mock_print.assert_called_with(
-                "[bold red]Error:[/bold red] Unsupported renderer type: invalid. Available renderers: table, raw, json, csv"
-            )
+        command_registry.cmd_format(["invalid"])
+        mock_print.assert_called_with(
+            "[bold red]Invalid format:[/bold red] 'invalid'. Available: table, raw"
+        )


### PR DESCRIPTION
- Validate language values upfront (gremlin, sparql, cypher, opencypher)
- Validate format values upfront (table, raw)
- Validate --type values in /connect (neptune, neptune-analytics, neo4j, tinkerpop)
- Remove undocumented gremlin-server alias
- Show clear error messages with available options

Assisted by [Amazon Q Developer](https://aws.amazon.com/q/developer)

*Issue #, if available:* https://github.com/awslabs/graphsh/issues/4

*Description of changes:* This change improves validation for some of the enum style parameters, and supports specifying opencypher.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
