### PR TITLE
feat(adapters): Add 10s connection timeout to database adapters

### DIFF
--- a/graphsh/db/adapters/neo4j.py
+++ b/graphsh/db/adapters/neo4j.py
@@ -141,7 +141,9 @@ class Neo4jAdapter(DatabaseAdapter):
                 driver_options[key] = value
 
         try:
-            self.driver = GraphDatabase.driver(uri, auth=auth, **driver_options)
+            self.driver = GraphDatabase.driver(
+                uri, auth=auth, connection_timeout=10, **driver_options
+            )
             # Test connection
             with self.driver.session() as session:
                 session.run("RETURN 1")

--- a/graphsh/db/adapters/neptune.py
+++ b/graphsh/db/adapters/neptune.py
@@ -214,7 +214,7 @@ class NeptuneAdapter(DatabaseAdapter):
                 protocol = "https" if self.use_ssl else "http"
                 status_endpoint = f"{protocol}://{self.host}:{self.port}/status"
 
-                response = self.http_session.get(status_endpoint)
+                response = self.http_session.get(status_endpoint, timeout=10)
                 response.raise_for_status()
 
                 logger.info(f"Connected to Neptune at {self.host}:{self.port}")

--- a/graphsh/db/adapters/neptune_analytics.py
+++ b/graphsh/db/adapters/neptune_analytics.py
@@ -10,6 +10,7 @@ import os
 from typing import Any, Dict, List
 
 import boto3
+from botocore.config import Config
 from botocore.exceptions import ClientError
 
 from graphsh.db.adapters.base import DatabaseAdapter
@@ -94,12 +95,17 @@ class NeptuneAnalyticsAdapter(DatabaseAdapter):
             else:
                 session = boto3.Session(region_name=self.region)
 
-            # Create neptune-graph client
-            self.client = session.client("neptune-graph", region_name=self.region)
+            # Create neptune-graph client with 10s connection timeout
+            config = Config(connect_timeout=10)
+            self.client = session.client(
+                "neptune-graph", region_name=self.region, config=config
+            )
 
-            # Test connection by describing the graph
+            # Test connection using data plane API (list_queries)
             try:
-                response = self.client.get_graph(graphIdentifier=self.graph_id)
+                self.client.list_queries(
+                    graphIdentifier=self.graph_id, maxResults=1, state="ALL"
+                )
                 logger.info(f"Connected to Neptune Analytics graph: {self.graph_id}")
                 return True
             except ClientError as e:

--- a/tests/db/adapters/test_neptune_analytics.py
+++ b/tests/db/adapters/test_neptune_analytics.py
@@ -44,7 +44,7 @@ def test_init_without_valid_endpoint():
 def test_connect_success(mock_boto3_session):
     """Test successful connection."""
     mock_session, mock_client = mock_boto3_session
-    mock_client.get_graph.return_value = {"graphId": "g-12445"}
+    mock_client.list_queries.return_value = {"queries": []}
 
     adapter = NeptuneAnalyticsAdapter(
         endpoint="g-12445.us-east-1.neptune-graph.amazonaws.com"
@@ -54,10 +54,14 @@ def test_connect_success(mock_boto3_session):
 
     assert result is True
     mock_session.assert_called_once_with(region_name="us-east-1")
-    mock_session.return_value.client.assert_called_once_with(
-        "neptune-graph", region_name="us-east-1"
+    # Verify client was called with config containing connect_timeout
+    call_args = mock_session.return_value.client.call_args
+    assert call_args[0][0] == "neptune-graph"
+    assert call_args[1]["region_name"] == "us-east-1"
+    assert call_args[1]["config"].connect_timeout == 10
+    mock_client.list_queries.assert_called_once_with(
+        graphIdentifier="g-12445", maxResults=1, state="ALL"
     )
-    mock_client.get_graph.assert_called_once_with(graphIdentifier="g-12445")
 
 
 def test_connect_failure(mock_boto3_session):
@@ -65,9 +69,9 @@ def test_connect_failure(mock_boto3_session):
     mock_session, mock_client = mock_boto3_session
     from botocore.exceptions import ClientError
 
-    mock_client.get_graph.side_effect = ClientError(
+    mock_client.list_queries.side_effect = ClientError(
         {"Error": {"Code": "ResourceNotFoundException", "Message": "Graph not found"}},
-        "GetGraph",
+        "ListQueries",
     )
 
     adapter = NeptuneAnalyticsAdapter(

--- a/tests/integration/neo4j/test_neo4j.py
+++ b/tests/integration/neo4j/test_neo4j.py
@@ -297,3 +297,16 @@ def test_neo4j_complex_query(neo4j_connection):
     assert "Bob" in output
     assert "David" in output
     assert "Charlie" in output
+
+
+def test_neo4j_connection_timeout():
+    """Test Neo4j adapter times out on unreachable endpoint."""
+    from graphsh.db.adapters.neo4j import Neo4jAdapter
+
+    adapter = Neo4jAdapter(
+        endpoint="bolt://192.0.2.1:7687",  # TEST-NET, non-routable
+        username="test",
+        password="test",
+    )
+    result = adapter.connect()
+    assert result is False

--- a/tests/integration/neptune/test_neptune.py
+++ b/tests/integration/neptune/test_neptune.py
@@ -859,3 +859,16 @@ def test_neptune_cypher_error_handling(neptune_connection):
 
     # Verify error message is displayed
     assert "error" in output.lower() or "exception" in output.lower() or "400" in output
+
+
+def test_neptune_connection_timeout():
+    """Test Neptune adapter times out on unreachable endpoint."""
+    from graphsh.db.adapters.neptune import NeptuneAdapter
+
+    adapter = NeptuneAdapter(
+        endpoint="192.0.2.1",  # TEST-NET, non-routable
+        port=8182,
+        auth_type="none",
+    )
+    result = adapter.connect()
+    assert result is False

--- a/tests/integration/neptune_analytics/test_neptune_analytics.py
+++ b/tests/integration/neptune_analytics/test_neptune_analytics.py
@@ -37,3 +37,15 @@ def test_neptune_analytics_count(neptune_analytics_connection):
     else:
         cnt = result[0].get("cnt")
     assert cnt >= 0
+
+
+def test_neptune_analytics_connection_timeout():
+    """Test Neptune Analytics adapter times out on unreachable endpoint."""
+    from graphsh.db.adapters.neptune_analytics import NeptuneAnalyticsAdapter
+
+    adapter = NeptuneAnalyticsAdapter(
+        graph_id="g-0000000000",
+        region="us-east-1",
+    )
+    result = adapter.connect()
+    assert result is False


### PR DESCRIPTION
- Neptune: Add timeout to status check request
- Neo4j: Add connection_timeout to driver
- Neptune Analytics: Use list_queries (data plane) instead of get_graph (control plane) for connection test, add botocore Config timeout
- Add integration tests for timeout behavior

Assisted by [Amazon Q Developer](https://aws.amazon.com/q/developer)

*Issue #, if available:* https://github.com/awslabs/graphsh/issues/9

*Description of changes:* Adds timeout for connect, integration tests for the same, and replaces Neptune Analytics validation with data api


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
